### PR TITLE
feat(booking): trust microcopy + what happens next

### DIFF
--- a/lang/de/ui.php
+++ b/lang/de/ui.php
@@ -585,6 +585,9 @@ return [
         'privacy_link' => 'Datenschutzrichtlinie',
         'send_booking_request' => 'Buchungsanfrage senden',
         'booking_reassurance' => 'Bestätigung innerhalb 24h &bull; Keine Zahlungsgebühren',
+        'trust_free_cancellation' => 'Kostenlose Stornierung gemäß Tour-Richtlinie',
+        'trust_response_time' => 'Wir antworten innerhalb von 1-2 Stunden',
+        'trust_no_hidden_fees' => 'Keine versteckten Gebühren — sicher online oder bar bezahlen',
 
         // Inquiry Form
         'inquiry_ask_title' => 'Fragen Sie uns zu dieser Tour',
@@ -703,6 +706,10 @@ return [
         'modal_guests' => 'GÄSTE',
         'modal_total' => 'GESAMT',
         'modal_sent_to' => 'Gesendet an',
+        'modal_what_next' => 'Wie geht es weiter?',
+        'modal_next_step1' => 'Prüfen Sie Ihre E-Mail für die Bestätigungsdetails.',
+        'modal_next_step2' => 'Wir senden Ihnen ein kurzes Formular zur Personalisierung Ihrer Reise.',
+        'modal_next_step3' => 'Guide- und Abholdetails erhalten Sie 48h vor der Tour.',
         'modal_choose_payment' => 'ZAHLUNG WÄHLEN',
         'modal_recommended' => 'EMPFOHLEN',
         'modal_pay_deposit' => ':percent% Anzahlung zahlen',

--- a/lang/en/ui.php
+++ b/lang/en/ui.php
@@ -159,6 +159,9 @@ return [
         'privacy_link' => 'Privacy Policy',
         'send_booking_request' => 'Send Booking Request',
         'booking_reassurance' => 'Booking confirmed within 24h &bull; No payment fees',
+        'trust_free_cancellation' => 'Free cancellation per tour policy',
+        'trust_response_time' => 'We respond within 1-2 hours',
+        'trust_no_hidden_fees' => 'No hidden fees — pay securely online or in cash',
 
         // Inquiry Form
         'inquiry_ask_title' => 'Ask Us About This Tour',
@@ -277,6 +280,10 @@ return [
         'modal_guests' => 'GUESTS',
         'modal_total' => 'TOTAL',
         'modal_sent_to' => 'Sent to',
+        'modal_what_next' => 'What happens next?',
+        'modal_next_step1' => 'Check your email for the confirmation details.',
+        'modal_next_step2' => 'We\'ll send you a short form to personalize your trip.',
+        'modal_next_step3' => 'Your guide and pickup details arrive 48h before the tour.',
         'modal_choose_payment' => 'CHOOSE PAYMENT',
         'modal_recommended' => 'RECOMMENDED',
         'modal_pay_deposit' => 'Pay :percent% Deposit',

--- a/lang/es/ui.php
+++ b/lang/es/ui.php
@@ -158,6 +158,9 @@ return [
         'privacy_link' => 'Politica de privacidad',
         'send_booking_request' => 'Enviar solicitud de reserva',
         'booking_reassurance' => 'Confirmacion en 24h &bull; Sin gastos de pago',
+        'trust_free_cancellation' => 'Cancelacion gratuita segun la politica del tour',
+        'trust_response_time' => 'Respondemos en 1-2 horas',
+        'trust_no_hidden_fees' => 'Sin cargos ocultos — pague en linea o en efectivo',
 
         // Inquiry Form
         'inquiry_ask_title' => 'Preguntenos sobre este tour',
@@ -276,6 +279,10 @@ return [
         'modal_guests' => 'HUÉSPEDES',
         'modal_total' => 'TOTAL',
         'modal_sent_to' => 'Enviado a',
+        'modal_what_next' => 'Que sigue?',
+        'modal_next_step1' => 'Revise su email para los detalles de confirmacion.',
+        'modal_next_step2' => 'Le enviaremos un breve formulario para personalizar su viaje.',
+        'modal_next_step3' => 'Los detalles de su guia y recogida llegan 48h antes del tour.',
         'modal_choose_payment' => 'ELEGIR PAGO',
         'modal_recommended' => 'RECOMENDADO',
         'modal_pay_deposit' => 'Pagar :percent% de depósito',

--- a/lang/fr/ui.php
+++ b/lang/fr/ui.php
@@ -363,6 +363,9 @@ return array (
     'privacy_link' => 'Politique de confidentialité',
     'send_booking_request' => 'Envoyer la demande de réservation',
     'booking_reassurance' => 'Confirmation sous 24h &bull; Sans frais de paiement',
+    'trust_free_cancellation' => 'Annulation gratuite selon la politique du tour',
+    'trust_response_time' => 'Nous répondons sous 1 à 2 heures',
+    'trust_no_hidden_fees' => 'Aucun frais caché — payez en ligne ou en espèces',
 
     // Inquiry Form
     'inquiry_ask_title' => 'Posez-nous une question sur ce circuit',
@@ -481,6 +484,10 @@ return array (
     'modal_guests' => 'INVITÉS',
     'modal_total' => 'TOTAL',
     'modal_sent_to' => 'Envoyé à',
+    'modal_what_next' => 'Et maintenant ?',
+    'modal_next_step1' => 'Consultez votre email pour les détails de confirmation.',
+    'modal_next_step2' => 'Nous vous enverrons un court formulaire pour personnaliser votre voyage.',
+    'modal_next_step3' => 'Les détails de votre guide et du point de rendez-vous arrivent 48h avant le tour.',
     'modal_choose_payment' => 'CHOISIR LE PAIEMENT',
     'modal_recommended' => 'RECOMMANDÉ',
     'modal_pay_deposit' => 'Payer :percent% d\'acompte',

--- a/lang/ja/ui.php
+++ b/lang/ja/ui.php
@@ -158,6 +158,9 @@ return [
         'privacy_link' => 'プライバシーポリシー',
         'send_booking_request' => '予約リクエストを送信',
         'booking_reassurance' => '24時間以内に予約確定 &bull; 手数料無料',
+        'trust_free_cancellation' => 'ツアーポリシーに基づく無料キャンセル',
+        'trust_response_time' => '1〜2時間以内に返信いたします',
+        'trust_no_hidden_fees' => '隠れた手数料なし — オンラインまたは現金でお支払い',
 
         // Inquiry Form
         'inquiry_ask_title' => 'このツアーについてお問い合わせ',
@@ -276,6 +279,10 @@ return [
         'modal_guests' => '人数',
         'modal_total' => '合計',
         'modal_sent_to' => '送信先',
+        'modal_what_next' => '次のステップ',
+        'modal_next_step1' => '確認メールをご確認ください。',
+        'modal_next_step2' => 'ツアー準備のための簡単なフォームをお送りします。',
+        'modal_next_step3' => 'ガイドと集合場所の詳細はツアー48時間前にお届けします。',
         'modal_choose_payment' => 'お支払い方法を選択',
         'modal_recommended' => '推奨',
         'modal_pay_deposit' => ':percent%の予約金を支払う',

--- a/lang/ru/ui.php
+++ b/lang/ru/ui.php
@@ -158,6 +158,9 @@ return [
         'privacy_link' => 'Политику конфиденциальности',
         'send_booking_request' => 'Отправить запрос на бронирование',
         'booking_reassurance' => 'Подтверждение в течение 24ч &bull; Без комиссий за оплату',
+        'trust_free_cancellation' => 'Бесплатная отмена согласно условиям тура',
+        'trust_response_time' => 'Мы отвечаем в течение 1-2 часов',
+        'trust_no_hidden_fees' => 'Без скрытых комиссий — оплата онлайн или наличными',
 
         // Inquiry Form
         'inquiry_ask_title' => 'Задайте вопрос об этом туре',
@@ -276,6 +279,10 @@ return [
         'modal_guests' => 'ГОСТЕЙ',
         'modal_total' => 'ИТОГО',
         'modal_sent_to' => 'Отправлено на',
+        'modal_what_next' => 'Что дальше?',
+        'modal_next_step1' => 'Проверьте вашу почту — мы отправили подтверждение.',
+        'modal_next_step2' => 'Мы пришлём короткую форму для подготовки вашего тура.',
+        'modal_next_step3' => 'Данные гида и место встречи — за 48 часов до тура.',
         'modal_choose_payment' => 'ВЫБЕРИТЕ СПОСОБ ОПЛАТЫ',
         'modal_recommended' => 'РЕКОМЕНДУЕТСЯ',
         'modal_pay_deposit' => 'Оплатить :percent% депозит',

--- a/resources/views/pages/tour-details.blade.php
+++ b/resources/views/pages/tour-details.blade.php
@@ -797,12 +797,20 @@
                     <span class="btn__text" id="submit-text">{{ __('ui.booking.send_booking_request') }}</span>
                     <span class="spinner"></span>
                   </button>
-                  <p style="text-align: center; margin-top: 8px; font-size: 11px; color: #666;">
-                    <svg width="12" height="12" viewBox="0 0 20 20" fill="#10b981" style="vertical-align: middle; margin-right: 4px;">
-                      <path d="M10 0C4.5 0 0 4.5 0 10s4.5 10 10 10 10-4.5 10-10S15.5 0 10 0zm4.7 7.7l-5 5c-.2.2-.4.3-.7.3s-.5-.1-.7-.3l-3-3c-.4-.4-.4-1 0-1.4s1-.4 1.4 0L9 10.6l4.3-4.3c.4-.4 1-.4 1.4 0s.4 1 0 1.4z"/>
-                    </svg>
-                    {!! __('ui.booking.booking_reassurance') !!}
-                  </p>
+                  <div style="margin-top: 10px; display: flex; flex-direction: column; gap: 4px;">
+                    <p style="display: flex; align-items: center; gap: 6px; margin: 0; font-size: 12px; color: #059669;">
+                      <svg width="14" height="14" viewBox="0 0 20 20" fill="#059669" style="flex-shrink: 0;"><path d="M10 0C4.5 0 0 4.5 0 10s4.5 10 10 10 10-4.5 10-10S15.5 0 10 0zm4.7 7.7l-5 5c-.2.2-.4.3-.7.3s-.5-.1-.7-.3l-3-3c-.4-.4-.4-1 0-1.4s1-.4 1.4 0L9 10.6l4.3-4.3c.4-.4 1-.4 1.4 0s.4 1 0 1.4z"/></svg>
+                      {{ __('ui.booking.trust_free_cancellation') }}
+                    </p>
+                    <p style="display: flex; align-items: center; gap: 6px; margin: 0; font-size: 12px; color: #059669;">
+                      <svg width="14" height="14" viewBox="0 0 20 20" fill="#059669" style="flex-shrink: 0;"><path d="M10 0C4.5 0 0 4.5 0 10s4.5 10 10 10 10-4.5 10-10S15.5 0 10 0zm4.7 7.7l-5 5c-.2.2-.4.3-.7.3s-.5-.1-.7-.3l-3-3c-.4-.4-.4-1 0-1.4s1-.4 1.4 0L9 10.6l4.3-4.3c.4-.4 1-.4 1.4 0s.4 1 0 1.4z"/></svg>
+                      {{ __('ui.booking.trust_response_time') }}
+                    </p>
+                    <p style="display: flex; align-items: center; gap: 6px; margin: 0; font-size: 12px; color: #059669;">
+                      <svg width="14" height="14" viewBox="0 0 20 20" fill="#059669" style="flex-shrink: 0;"><path d="M10 0C4.5 0 0 4.5 0 10s4.5 10 10 10 10-4.5 10-10S15.5 0 10 0zm4.7 7.7l-5 5c-.2.2-.4.3-.7.3s-.5-.1-.7-.3l-3-3c-.4-.4-.4-1 0-1.4s1-.4 1.4 0L9 10.6l4.3-4.3c.4-.4 1-.4 1.4 0s.4 1 0 1.4z"/></svg>
+                      {{ __('ui.booking.trust_no_hidden_fees') }}
+                    </p>
+                  </div>
 
                   {{-- PDF Download Button (Secondary Action) --}}
                   @include("partials.tours.download-pdf-button", ["tour" => $tour, "variant" => "sidebar"])
@@ -1272,6 +1280,25 @@
             <path d="M2 4v8c0 .6.4 1 1 1h10c.6 0 1-.4 1-1V4c0-.6-.4-1-1-1H3c-.6 0-1 .4-1 1zm12 0L8 8.5 2 4h12zM3 12V5.3l4.7 3.5c.2.1.4.2.6.2s.4-.1.6-.2L14 5.3V12H3z"/>
           </svg>
           <span>{{ __('ui.booking.modal_sent_to') }} <span id="modal-customer-email">your email</span></span>
+        </div>
+
+        <!-- What Happens Next -->
+        <div style="background: #F0FDF4; border: 1px solid #BBF7D0; border-radius: 8px; padding: 12px 14px; margin: 12px 0;">
+          <p style="font-size: 12px; font-weight: 600; color: #166534; margin: 0 0 8px 0; text-transform: uppercase; letter-spacing: 0.3px;">{{ __('ui.booking.modal_what_next') }}</p>
+          <div style="display: flex; flex-direction: column; gap: 6px;">
+            <p style="display: flex; align-items: flex-start; gap: 8px; margin: 0; font-size: 12px; color: #15803D; line-height: 1.4;">
+              <span style="font-weight: 600; flex-shrink: 0;">1.</span>
+              {{ __('ui.booking.modal_next_step1') }}
+            </p>
+            <p style="display: flex; align-items: flex-start; gap: 8px; margin: 0; font-size: 12px; color: #15803D; line-height: 1.4;">
+              <span style="font-weight: 600; flex-shrink: 0;">2.</span>
+              {{ __('ui.booking.modal_next_step2') }}
+            </p>
+            <p style="display: flex; align-items: flex-start; gap: 8px; margin: 0; font-size: 12px; color: #15803D; line-height: 1.4;">
+              <span style="font-weight: 600; flex-shrink: 0;">3.</span>
+              {{ __('ui.booking.modal_next_step3') }}
+            </p>
+          </div>
         </div>
 
         <!-- Payment Options Compact -->


### PR DESCRIPTION
## Summary
- 3 trust signals below booking CTA (free cancellation, response time, no hidden fees)
- "What happens next?" section in confirmation modal (prepares guest for trip details email)
- All 6 languages translated (en, fr, de, ru, es, ja)

## Files Changed
- `resources/views/pages/tour-details.blade.php` (2 sections)
- `lang/*/ui.php` (6 files, 8 new keys each)

## Test Plan
- [ ] Open any tour page, scroll to booking form, verify 3 green trust lines below "Send Booking Request"
- [ ] Submit a booking, verify "What happens next?" section appears in confirmation modal before payment options
- [ ] Switch language (fr, de, ru), verify translations display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)