### PR TITLE
feat: trip_details migration + model + booking relationship

### DIFF
--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -168,6 +168,11 @@ class Booking extends Model
         return $this->hasMany(Passenger::class);
     }
 
+    public function tripDetail()
+    {
+        return $this->hasOne(TripDetail::class);
+    }
+
     public function passengerReminderLogs()
     {
         return $this->hasMany(PassengerReminderLog::class);
@@ -396,6 +401,22 @@ class Booking extends Model
     // ============================================
     // BOOKING TYPE HELPER METHODS
     // ============================================
+
+    /**
+     * Check if this booking needs full trip details (long tour: 3+ days)
+     */
+    public function needsFullTripDetails(): bool
+    {
+        return $this->tour && $this->tour->duration_days > 2;
+    }
+
+    /**
+     * Check if trip details have been submitted
+     */
+    public function hasTripDetails(): bool
+    {
+        return $this->tripDetail && $this->tripDetail->isCompleted();
+    }
 
     /**
      * Check if this is a private tour booking

--- a/app/Models/TripDetail.php
+++ b/app/Models/TripDetail.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TripDetail extends Model
+{
+    protected $fillable = [
+        'booking_id',
+        'hotel_name',
+        'hotel_address',
+        'whatsapp_number',
+        'arrival_date',
+        'arrival_flight',
+        'arrival_time',
+        'departure_date',
+        'departure_flight',
+        'departure_time',
+        'language_preference',
+        'referral_source',
+        'additional_notes',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'arrival_date' => 'date',
+        'departure_date' => 'date',
+        'completed_at' => 'datetime',
+    ];
+
+    public function booking(): BelongsTo
+    {
+        return $this->belongsTo(Booking::class);
+    }
+
+    /**
+     * Check if trip details form has been completed
+     */
+    public function isCompleted(): bool
+    {
+        return !is_null($this->completed_at);
+    }
+
+    /**
+     * Check if this is for a mini tour (duration <= 2 days)
+     */
+    public function isMiniTour(): bool
+    {
+        return $this->booking->tour->duration_days <= 2;
+    }
+
+    /**
+     * Get required fields based on tour type
+     * Mini tours: hotel + whatsapp + referral
+     * Long tours: all fields
+     */
+    public function getRequiredFields(): array
+    {
+        $base = ['hotel_name', 'whatsapp_number'];
+
+        if (!$this->isMiniTour()) {
+            $base = array_merge($base, [
+                'arrival_date',
+                'arrival_flight',
+                'departure_date',
+                'departure_flight',
+            ]);
+        }
+
+        return $base;
+    }
+
+    /**
+     * Check if all required fields are filled
+     */
+    public function hasRequiredFields(): bool
+    {
+        foreach ($this->getRequiredFields() as $field) {
+            if (empty($this->$field)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/database/migrations/2026_02_15_120000_create_trip_details_table.php
+++ b/database/migrations/2026_02_15_120000_create_trip_details_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('trip_details', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('booking_id')->constrained()->cascadeOnDelete();
+
+            // Accommodation (mini + long tours)
+            $table->string('hotel_name')->nullable();
+            $table->string('hotel_address')->nullable();
+
+            // Communication (mini + long tours)
+            $table->string('whatsapp_number')->nullable();
+
+            // Travel logistics (long tours only)
+            $table->date('arrival_date')->nullable();
+            $table->string('arrival_flight')->nullable();
+            $table->string('arrival_time')->nullable();
+            $table->date('departure_date')->nullable();
+            $table->string('departure_flight')->nullable();
+            $table->string('departure_time')->nullable();
+
+            // Preferences
+            $table->string('language_preference')->nullable();
+
+            // Marketing attribution
+            $table->string('referral_source')->nullable();
+
+            // Additional info
+            $table->text('additional_notes')->nullable();
+
+            // Tracking
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('trip_details');
+    }
+};


### PR DESCRIPTION
## Summary
- New `trip_details` table for travel logistics (hotel, flights, WhatsApp, language preference, referral source)
- `TripDetail` model with adaptive required fields — mini tours (≤2 days) need only hotel + WhatsApp, long tours (3+ days) need full flight details
- `tripDetail()` hasOne relationship on Booking model
- `needsFullTripDetails()` and `hasTripDetails()` helpers on Booking

Complements existing `Passenger` model (identity/passport docs) with travel logistics data.

## Test plan
- [ ] Run `php artisan migrate` — verify trip_details table created
- [ ] Verify Booking model loads without errors
- [ ] Check `TripDetail::getRequiredFields()` returns correct fields for mini vs long tours

🤖 Generated with [Claude Code](https://claude.com/claude-code)