### PR TITLE
feat: add trip details link to booking confirmation email

### DIFF
--- a/app/Mail/BookingConfirmation.php
+++ b/app/Mail/BookingConfirmation.php
@@ -14,6 +14,7 @@ class BookingConfirmation extends Mailable
 
     public $booking;
     public $customer;
+    public $tripDetailsUrl;
 
     /**
      * Create a new message instance.
@@ -22,6 +23,7 @@ class BookingConfirmation extends Mailable
     {
         $this->booking = $booking;
         $this->customer = $customer;
+        $this->tripDetailsUrl = $booking->getTripDetailsUrl();
     }
 
     /**

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -403,6 +403,16 @@ class Booking extends Model
     // ============================================
 
     /**
+     * Get trip details form URL (for post-booking email)
+     */
+    public function getTripDetailsUrl(): string
+    {
+        $token = $this->generatePassengerDetailsToken();
+
+        return route('trip-details.show', ['token' => $token]);
+    }
+
+    /**
      * Check if this booking needs full trip details (long tour: 3+ days)
      */
     public function needsFullTripDetails(): bool

--- a/resources/views/emails/bookings/confirmation.blade.php
+++ b/resources/views/emails/bookings/confirmation.blade.php
@@ -29,6 +29,16 @@ We have successfully received your booking request and our team is now reviewing
 {{ $booking->special_requests }}
 @endif
 
+## Help Us Personalize Your Trip
+
+To ensure everything runs smoothly, please take a moment to share your travel details — hotel info, WhatsApp number{{ $booking->needsFullTripDetails() ? ', flight details' : '' }}, and preferences.
+
+@component('mail::button', ['url' => $tripDetailsUrl, 'color' => 'primary'])
+Fill In Trip Details
+@endcomponent
+
+*This takes about 2 minutes and helps us arrange {{ $booking->needsFullTripDetails() ? 'airport pickup, hotel transfers, and guide coordination' : 'pickup and guide coordination' }}.*
+
 ## What Happens Next?
 
 Our travel experts will review your booking and get back to you within **24 hours** to:


### PR DESCRIPTION
## Summary
- Adds "Help Us Personalize Your Trip" section to booking confirmation email
- Blue CTA button links to `/trip-details/{token}` page
- Adaptive copy: long tours (3+ days) mention airport pickup & flights, mini tours keep it simple
- Adds `getTripDetailsUrl()` helper on Booking model
- Token auto-generated on first email send (reuses existing `passenger_details_url_token`)

Only 3 files changed, 22 lines added — minimal, focused change.

## Test plan
- [x] Email renders with trip details button (verified via `$mail->render()`)
- [x] URL points to correct trip-details route
- [x] Long tour copy includes "flight details" mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)