### PR TITLE
feat: store guest locale at booking time

### DIFF
--- a/app/Http/Controllers/Partials/BookingController.php
+++ b/app/Http/Controllers/Partials/BookingController.php
@@ -236,6 +236,7 @@ class BookingController extends Controller
                 'status' => 'pending_payment',
                 'payment_method' => $paymentMethod,
                 'payment_status' => 'pending',
+                'locale' => app()->getLocale(),
             ]);
 
             // Attach optional extras to booking

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -43,6 +43,8 @@ class Booking extends Model
         'payment_type',
         'deposit_percentage',
         'payment_uuid',
+        // Guest locale (detected at booking time)
+        'locale',
         // OTA integration
         'source',
         'external_reference',

--- a/database/migrations/2026_02_15_150000_add_locale_to_bookings_table.php
+++ b/database/migrations/2026_02_15_150000_add_locale_to_bookings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            $table->string('locale', 5)->default('en')->after('source');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            $table->dropColumn('locale');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Adds `locale` column to bookings table (varchar 5, default 'en')
- Captures `app()->getLocale()` when booking is created
- Enables sending emails and reminders in the guest's language later

3 files, 25 lines.

## Test plan
- [x] Migration runs clean
- [x] Existing bookings get 'en' default
- [x] locale in fillable array

🤖 Generated with [Claude Code](https://claude.com/claude-code)