### PR TITLE
feat(emails): pre-trip notification day before tour

### DIFF
--- a/app/Console/Commands/SendPreTripNotifications.php
+++ b/app/Console/Commands/SendPreTripNotifications.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\PreTripNotification;
+use App\Models\Booking;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class SendPreTripNotifications extends Command
+{
+    protected $signature = 'reminders:pre-trip {--dry-run : Preview without sending}';
+
+    protected $description = 'Send "your tour is tomorrow" notification to guests';
+
+    public function handle()
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN MODE - No emails will be sent');
+        }
+
+        $tomorrow = now()->addDay()->toDateString();
+
+        $bookings = Booking::where('status', 'confirmed')
+            ->whereDate('start_date', $tomorrow)
+            ->with(['customer', 'tour', 'tripDetail'])
+            ->get();
+
+        $sent = 0;
+
+        foreach ($bookings as $booking) {
+            if (!$booking->customer?->email) {
+                $this->warn("Skipping {$booking->reference}: no customer email");
+                continue;
+            }
+
+            if ($dryRun) {
+                $this->line("Would send to: {$booking->customer->email} ({$booking->reference}, tour: {$booking->tour->title})");
+                $sent++;
+                continue;
+            }
+
+            try {
+                Mail::to($booking->customer->email)
+                    ->send(new PreTripNotification($booking));
+
+                $this->info("Sent to: {$booking->customer->email} ({$booking->reference})");
+
+                Log::info('Pre-trip notification sent', [
+                    'booking_id' => $booking->id,
+                    'reference' => $booking->reference,
+                    'email' => $booking->customer->email,
+                    'start_date' => $booking->start_date->toDateString(),
+                ]);
+
+                $sent++;
+            } catch (\Exception $e) {
+                $this->error("Failed: {$booking->customer->email} - {$e->getMessage()}");
+                Log::error('Pre-trip notification failed', [
+                    'booking_id' => $booking->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $this->info("Done. Notifications sent: {$sent}");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Mail/PreTripNotification.php
+++ b/app/Mail/PreTripNotification.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Booking;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class PreTripNotification extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public $booking;
+
+    public function __construct(Booking $booking)
+    {
+        $this->booking = $booking;
+    }
+
+    public function build()
+    {
+        return $this->subject("Tomorrow is the day! {$this->booking->tour->title}")
+                    ->markdown('emails.pre-trip.notification');
+    }
+}

--- a/resources/views/emails/pre-trip/notification.blade.php
+++ b/resources/views/emails/pre-trip/notification.blade.php
@@ -1,0 +1,47 @@
+@component('mail::message')
+# Your Tour Starts Tomorrow!
+
+Dear {{ $booking->customer->name }},
+
+We're excited — your tour **{{ $booking->tour->title }}** begins tomorrow, **{{ $booking->start_date->format('F j, Y') }}**!
+
+@component('mail::panel')
+**Booking Reference:** {{ $booking->reference }}<br>
+**Tour Date:** {{ $booking->start_date->format('F j, Y') }}<br>
+**Guests:** {{ $booking->pax_total }} {{ $booking->pax_total === 1 ? 'guest' : 'guests' }}
+@if($booking->guide_name)
+<br>**Your Guide:** {{ $booking->guide_name }}{{ $booking->guide_phone ? ' ('.$booking->guide_phone.')' : '' }}
+@endif
+@if($booking->driver_name)
+<br>**Driver:** {{ $booking->driver_name }}{{ $booking->driver_phone ? ' ('.$booking->driver_phone.')' : '' }}
+@endif
+@if($booking->vehicle_info)
+<br>**Vehicle:** {{ $booking->vehicle_info }}
+@endif
+@endcomponent
+
+@if($booking->tripDetail && $booking->tripDetail->hotel_name)
+**Pickup:** We'll collect you from **{{ $booking->tripDetail->hotel_name }}**{{ $booking->tripDetail->hotel_address ? ' ('.$booking->tripDetail->hotel_address.')' : '' }} in the morning.
+@endif
+
+@if($booking->tripDetail && $booking->tripDetail->whatsapp_number)
+Your guide will contact you on WhatsApp (**{{ $booking->tripDetail->whatsapp_number }}**) with the exact pickup time.
+@else
+Your guide will contact you with the exact pickup time.
+@endif
+
+**Quick checklist for tomorrow:**
+- Comfortable walking shoes
+- Sunscreen & water bottle
+- Camera for the amazing views
+- Valid ID / passport
+
+We look forward to showing you the best of Uzbekistan!
+
+Best regards,<br>
+**The Jahongir Travel Team**
+
+---
+
+*If you have questions, reply to this email or contact us at support@jahongir-hotels.uz*
+@endcomponent

--- a/routes/console.php
+++ b/routes/console.php
@@ -39,6 +39,16 @@ Schedule::command('reminders:trip-details')
     ->appendOutputTo(storage_path('logs/trip-details-reminders.log'));
 
 // ============================================
+// PRE-TRIP NOTIFICATION (DAY BEFORE TOUR)
+// ============================================
+
+Schedule::command('reminders:pre-trip')
+    ->dailyAt('16:00')
+    ->timezone('Asia/Tashkent')
+    ->emailOutputOnFailure(config('mail.from.address'))
+    ->appendOutputTo(storage_path('logs/pre-trip-notifications.log'));
+
+// ============================================
 // TOUR OPERATOR REMINDER SCHEDULER
 // ============================================
 


### PR DESCRIPTION
## Summary
- Sends "Your tour is tomorrow!" email to guests the day before their tour
- Includes guide name/phone, driver info, vehicle details (if assigned in booking)
- Shows hotel pickup info from trip details
- Packing checklist (shoes, sunscreen, camera, ID)
- Scheduled daily at 16:00 Tashkent time
- `--dry-run` flag for testing

## Sprint 3, PR 10

## Test plan
- [ ] `php artisan reminders:pre-trip --dry-run` runs without errors
- [ ] Email renders correctly (tested via tinker)
- [ ] Only targets confirmed bookings with start_date = tomorrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)