### PR TITLE
feat(pdf): itinerary PDF generation and download

### DIFF
--- a/app/Http/Controllers/ItineraryPdfController.php
+++ b/app/Http/Controllers/ItineraryPdfController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Booking;
+use App\Services\ItineraryPdfService;
+
+class ItineraryPdfController extends Controller
+{
+    public function download(string $token, ItineraryPdfService $pdfService)
+    {
+        $booking = Booking::where('passenger_details_url_token', $token)
+            ->with(['tour', 'customer', 'tripDetail'])
+            ->firstOrFail();
+
+        $pdf = $pdfService->generate($booking);
+        $filename = $pdfService->filename($booking);
+
+        return $pdf->download($filename);
+    }
+}

--- a/app/Mail/PreTripNotification.php
+++ b/app/Mail/PreTripNotification.php
@@ -3,6 +3,7 @@
 namespace App\Mail;
 
 use App\Models\Booking;
+use App\Services\ItineraryPdfService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
@@ -21,7 +22,23 @@ class PreTripNotification extends Mailable implements ShouldQueue
 
     public function build()
     {
-        return $this->subject("Tomorrow is the day! {$this->booking->tour->title}")
+        $mail = $this->subject("Tomorrow is the day! {$this->booking->tour->title}")
                     ->markdown('emails.pre-trip.notification');
+
+        try {
+            $pdfService = app(ItineraryPdfService::class);
+            $mail->attachData(
+                $pdfService->generateContent($this->booking),
+                $pdfService->filename($this->booking),
+                ['mime' => 'application/pdf']
+            );
+        } catch (\Exception $e) {
+            \Illuminate\Support\Facades\Log::warning('Could not attach itinerary PDF', [
+                'booking_id' => $this->booking->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $mail;
     }
 }

--- a/app/Services/ItineraryPdfService.php
+++ b/app/Services/ItineraryPdfService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Booking;
+use Barryvdh\DomPDF\Facade\Pdf;
+
+class ItineraryPdfService
+{
+    public function generate(Booking $booking): \Barryvdh\DomPDF\PDF
+    {
+        $booking->loadMissing(['tour', 'customer', 'tripDetail']);
+        $tour = $booking->tour;
+
+        // Get itinerary from translation first, fallback to tour columns
+        $translation = $tour->translations()->where('locale', 'en')->first();
+
+        $itinerary = $this->resolveJsonField($translation?->itinerary_json);
+        $highlights = $this->resolveJsonField($translation?->highlights_json) ?: $this->resolveJsonField($tour->highlights);
+        $included = $this->resolveJsonField($translation?->included_json) ?: $this->resolveJsonField($tour->included_items);
+        $excluded = $this->resolveJsonField($translation?->excluded_json) ?: $this->resolveJsonField($tour->excluded_items);
+
+        return Pdf::loadView('pdf.itinerary', [
+            'booking' => $booking,
+            'tour' => $tour,
+            'tripDetail' => $booking->tripDetail,
+            'itinerary' => $itinerary,
+            'highlights' => $highlights,
+            'included' => $included,
+            'excluded' => $excluded,
+        ])->setPaper('a4');
+    }
+
+    public function generateContent(Booking $booking): string
+    {
+        return $this->generate($booking)->output();
+    }
+
+    public function filename(Booking $booking): string
+    {
+        $slug = str($booking->tour->title)->slug()->limit(40, '');
+        return "itinerary-{$booking->reference}-{$slug}.pdf";
+    }
+
+    private function resolveJsonField($value): ?array
+    {
+        if (is_array($value) && count($value) > 0) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded) && count($decoded) > 0) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+}

--- a/resources/views/pages/trip-details-confirm.blade.php
+++ b/resources/views/pages/trip-details-confirm.blade.php
@@ -312,7 +312,13 @@
                 </ul>
             </div>
 
-            <a href="{{ route('trip-details.show', ['token' => $token]) }}" class="btn-edit">Edit Details</a>
+            <div style="display: flex; gap: 0.75rem; margin-top: 1rem; flex-wrap: wrap;">
+                <a href="{{ route('trip-details.itinerary-pdf', ['token' => $token]) }}" class="btn-edit" style="background: #1d4ed8; color: white; border-color: #1d4ed8;">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align: -3px; margin-right: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                    Download Itinerary PDF
+                </a>
+                <a href="{{ route('trip-details.show', ['token' => $token]) }}" class="btn-edit">Edit Details</a>
+            </div>
         </div>
 
         <div class="footer">

--- a/resources/views/pdf/itinerary.blade.php
+++ b/resources/views/pdf/itinerary.blade.php
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: DejaVu Sans, sans-serif; font-size: 11px; color: #1f2937; line-height: 1.5; }
+
+        .header {
+            background: #1d4ed8;
+            color: white;
+            padding: 30px;
+            text-align: center;
+        }
+        .header h1 { font-size: 22px; margin-bottom: 4px; }
+        .header .subtitle { font-size: 12px; opacity: 0.9; }
+
+        .meta-bar {
+            background: #eff6ff;
+            padding: 12px 30px;
+            display: table;
+            width: 100%;
+            font-size: 10px;
+        }
+        .meta-item {
+            display: table-cell;
+            text-align: center;
+            padding: 0 8px;
+        }
+        .meta-label { color: #6b7280; font-size: 9px; text-transform: uppercase; }
+        .meta-value { font-weight: 700; color: #1d4ed8; margin-top: 2px; }
+
+        .content { padding: 25px 30px; }
+
+        .section { margin-bottom: 20px; }
+        .section-title {
+            font-size: 14px;
+            font-weight: 700;
+            color: #1d4ed8;
+            border-bottom: 2px solid #dbeafe;
+            padding-bottom: 4px;
+            margin-bottom: 10px;
+        }
+
+        .description { font-size: 11px; line-height: 1.6; color: #374151; }
+
+        .highlights-list, .include-list {
+            list-style: none;
+            padding: 0;
+        }
+        .highlights-list li, .include-list li {
+            padding: 3px 0 3px 18px;
+            position: relative;
+            font-size: 11px;
+        }
+        .highlights-list li::before {
+            content: "\2605";
+            position: absolute;
+            left: 0;
+            color: #f59e0b;
+        }
+        .include-list.included li::before {
+            content: "\2713";
+            position: absolute;
+            left: 0;
+            color: #16a34a;
+            font-weight: 700;
+        }
+        .include-list.excluded li::before {
+            content: "\2717";
+            position: absolute;
+            left: 0;
+            color: #dc2626;
+            font-weight: 700;
+        }
+
+        .itinerary-day {
+            margin-bottom: 12px;
+            padding: 10px;
+            background: #f9fafb;
+            border-radius: 6px;
+            border-left: 3px solid #1d4ed8;
+        }
+        .itinerary-day-title {
+            font-weight: 700;
+            font-size: 12px;
+            color: #1d4ed8;
+            margin-bottom: 4px;
+        }
+        .itinerary-day-desc { font-size: 10.5px; color: #4b5563; }
+
+        .trip-details-box {
+            background: #f0fdf4;
+            border: 1px solid #bbf7d0;
+            border-radius: 6px;
+            padding: 12px 15px;
+        }
+        .trip-details-box .td-row {
+            display: table;
+            width: 100%;
+            padding: 3px 0;
+        }
+        .td-label {
+            display: table-cell;
+            width: 120px;
+            font-size: 10px;
+            color: #6b7280;
+            font-weight: 600;
+        }
+        .td-value {
+            display: table-cell;
+            font-size: 11px;
+            color: #111827;
+        }
+
+        .two-col { display: table; width: 100%; }
+        .two-col .col { display: table-cell; width: 48%; vertical-align: top; }
+        .two-col .col-gap { display: table-cell; width: 4%; }
+
+        .footer {
+            margin-top: 20px;
+            padding: 15px 30px;
+            background: #f9fafb;
+            text-align: center;
+            font-size: 9px;
+            color: #9ca3af;
+        }
+
+        .page-break { page-break-before: always; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>{{ $tour->title }}</h1>
+        <div class="subtitle">{{ $tour->duration_text ?? $tour->duration_days . ' days' }}</div>
+    </div>
+
+    <div class="meta-bar">
+        <div class="meta-item">
+            <div class="meta-label">Booking</div>
+            <div class="meta-value">{{ $booking->reference }}</div>
+        </div>
+        <div class="meta-item">
+            <div class="meta-label">Guest</div>
+            <div class="meta-value">{{ $booking->customer->name }}</div>
+        </div>
+        <div class="meta-item">
+            <div class="meta-label">Date</div>
+            <div class="meta-value">{{ $booking->start_date->format('M j, Y') }}{{ $booking->end_date ? ' — ' . $booking->end_date->format('M j, Y') : '' }}</div>
+        </div>
+        <div class="meta-item">
+            <div class="meta-label">Guests</div>
+            <div class="meta-value">{{ $booking->pax_total }}</div>
+        </div>
+    </div>
+
+    <div class="content">
+        {{-- Description --}}
+        @if($tour->short_description)
+        <div class="section">
+            <div class="description">{{ $tour->short_description }}</div>
+        </div>
+        @endif
+
+        {{-- Highlights --}}
+        @if($highlights && count($highlights) > 0)
+        <div class="section">
+            <div class="section-title">Tour Highlights</div>
+            <ul class="highlights-list">
+                @foreach($highlights as $h)
+                <li>{{ is_array($h) ? ($h['text'] ?? $h[0] ?? '') : $h }}</li>
+                @endforeach
+            </ul>
+        </div>
+        @endif
+
+        {{-- Itinerary --}}
+        @if($itinerary && count($itinerary) > 0)
+        <div class="section">
+            <div class="section-title">Day-by-Day Itinerary</div>
+            @foreach($itinerary as $day)
+            <div class="itinerary-day">
+                <div class="itinerary-day-title">Day {{ $day['day'] ?? $loop->iteration }}: {{ $day['title'] ?? '' }}</div>
+                @if(!empty($day['description']))
+                <div class="itinerary-day-desc">{{ $day['description'] }}</div>
+                @endif
+            </div>
+            @endforeach
+        </div>
+        @endif
+
+        {{-- Included / Excluded --}}
+        @if(($included && count($included) > 0) || ($excluded && count($excluded) > 0))
+        <div class="section">
+            <div class="two-col">
+                @if($included && count($included) > 0)
+                <div class="col">
+                    <div class="section-title">What's Included</div>
+                    <ul class="include-list included">
+                        @foreach($included as $item)
+                        <li>{{ is_array($item) ? ($item['text'] ?? $item[0] ?? '') : $item }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+                @endif
+                @if($included && $excluded)
+                <div class="col-gap"></div>
+                @endif
+                @if($excluded && count($excluded) > 0)
+                <div class="col">
+                    <div class="section-title">Not Included</div>
+                    <ul class="include-list excluded">
+                        @foreach($excluded as $item)
+                        <li>{{ is_array($item) ? ($item['text'] ?? $item[0] ?? '') : $item }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+                @endif
+            </div>
+        </div>
+        @endif
+
+        {{-- Trip Details --}}
+        @if($tripDetail)
+        <div class="section">
+            <div class="section-title">Your Trip Details</div>
+            <div class="trip-details-box">
+                @if($tripDetail->whatsapp_number)
+                <div class="td-row"><div class="td-label">WhatsApp</div><div class="td-value">{{ $tripDetail->whatsapp_number }}</div></div>
+                @endif
+                @if($tripDetail->hotel_name)
+                <div class="td-row"><div class="td-label">Hotel</div><div class="td-value">{{ $tripDetail->hotel_name }}{{ $tripDetail->hotel_address ? ' — ' . $tripDetail->hotel_address : '' }}</div></div>
+                @endif
+                @if($tripDetail->arrival_date)
+                <div class="td-row"><div class="td-label">Arrival</div><div class="td-value">{{ $tripDetail->arrival_date->format('M j, Y') }}{{ $tripDetail->arrival_flight ? ' — ' . $tripDetail->arrival_flight : '' }}{{ $tripDetail->arrival_time ? ' at ' . $tripDetail->arrival_time : '' }}</div></div>
+                @endif
+                @if($tripDetail->departure_date)
+                <div class="td-row"><div class="td-label">Departure</div><div class="td-value">{{ $tripDetail->departure_date->format('M j, Y') }}{{ $tripDetail->departure_flight ? ' — ' . $tripDetail->departure_flight : '' }}{{ $tripDetail->departure_time ? ' at ' . $tripDetail->departure_time : '' }}</div></div>
+                @endif
+                @if($tripDetail->language_preference)
+                <div class="td-row"><div class="td-label">Language</div><div class="td-value">{{ ucfirst($tripDetail->language_preference) }}</div></div>
+                @endif
+            </div>
+        </div>
+        @endif
+
+        {{-- Guide & Driver --}}
+        @if($booking->guide_name || $booking->driver_name)
+        <div class="section">
+            <div class="section-title">Your Team</div>
+            <div class="trip-details-box">
+                @if($booking->guide_name)
+                <div class="td-row"><div class="td-label">Guide</div><div class="td-value">{{ $booking->guide_name }}{{ $booking->guide_phone ? ' (' . $booking->guide_phone . ')' : '' }}</div></div>
+                @endif
+                @if($booking->driver_name)
+                <div class="td-row"><div class="td-label">Driver</div><div class="td-value">{{ $booking->driver_name }}{{ $booking->driver_phone ? ' (' . $booking->driver_phone . ')' : '' }}</div></div>
+                @endif
+                @if($booking->vehicle_info)
+                <div class="td-row"><div class="td-label">Vehicle</div><div class="td-value">{{ $booking->vehicle_info }}</div></div>
+                @endif
+            </div>
+        </div>
+        @endif
+    </div>
+
+    <div class="footer">
+        <p><strong>Jahongir Travel</strong> &bull; support@jahongir-hotels.uz</p>
+        <p>This document was generated for {{ $booking->customer->name }} &bull; {{ now()->format('F j, Y') }}</p>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -582,6 +582,9 @@ Route::post('/trip-details/{token}', [\App\Http\Controllers\TripDetailController
 Route::get('/trip-details/{token}/confirm', [\App\Http\Controllers\TripDetailController::class, 'confirm'])
     ->name('trip-details.confirm');
 
+Route::get('/trip-details/{token}/itinerary.pdf', [\App\Http\Controllers\ItineraryPdfController::class, 'download'])
+    ->name('trip-details.itinerary-pdf');
+
 // ============================================
 // PAYMENT ROUTES
 // ============================================


### PR DESCRIPTION
## Summary
- New `ItineraryPdfService` generates branded PDF from tour data (highlights, included/excluded, itinerary, guest trip details, guide/driver info)
- Guest download route at `/trip-details/{token}/itinerary.pdf`
- "Download Itinerary PDF" button added to confirmation page
- PDF auto-attached to pre-trip notification email (with graceful fallback)
- Uses existing `barryvdh/laravel-dompdf` package

## Sprint 3, PR 11 (final Sprint 3 item)

## Test plan
- [ ] Go to confirmation page → click "Download Itinerary PDF" → PDF downloads
- [ ] PDF shows tour title, booking ref, highlights, included/excluded, trip details
- [ ] Pre-trip email now has PDF attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)